### PR TITLE
change location of repo

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -23,4 +23,4 @@ function ansible-control-banner() {
 
 ansible-control-banner  
 workon ansible
-cd ~/ansible/commcarehq-ansible/ansible
+cd ~/commcarehq-ansible/ansible


### PR DESCRIPTION
Following the instructions [here](https://confluence.dimagi.com/display/commcarehq/Bootstrapping+a+Control+Machine), this repo is directly in the home dir.
@dannyroberts @benrudolph 
